### PR TITLE
Logging: Change `print` messages to full sentence with detail information

### DIFF
--- a/removepassword.py
+++ b/removepassword.py
@@ -68,6 +68,10 @@ src_file_path = os.environ.get('DOCUMENT_WORKING_PATH')
 pass_file_path = "/usr/src/paperless/scripts/passwords.txt"
 consume_path = "/usr/src/paperless/consume/"
 
+# Script execution
+task_id = os.environ.get('TASK_ID')
+print(f"Kicking off pre-consumption script for task {task_id}")
+
 if src_file_path is None:
     print("No file path available in environment variable 'DOCUMENT_WORKING_PATH'")
     exit(0)

--- a/removepassword.py
+++ b/removepassword.py
@@ -26,24 +26,25 @@ def pdf_has_attachments(file_path: str) -> bool:
 
 def unlock_pdf(file_path: str):
     password = None
-    print("reading passwords")
+    print(f"Reading document passwords into memory from {pass_file_path}")
     with open(pass_file_path, "r") as f:
         passwords = f.readlines()
+
     for p in passwords:
         password = p.strip()
         try:
             with pikepdf.open(
                 file_path, password=password, allow_overwriting_input=True
             ) as pdf:
-                # print("password is working")
-                print("unlocked succesfully")
+                print(f"Document {file_path} was decrypted succesfully")
                 pdf.save(file_path, deterministic_id=True)
                 break
         except pikepdf.PasswordError:
-            print("password is not working")
+            print(f"No password from file {pass_file_path} is working for file {file_path}")
             continue
+
     if password is None:
-        print("empty password file")
+        print(f"Password file {pass_file_path} is empty")
 
 
 def extract_pdf_attachments(file_path: str):
@@ -56,35 +57,33 @@ def extract_pdf_attachments(file_path: str):
                 try:
                     with open(trg_file_path, "wb") as wb:
                         wb.write(ats.get(atm).obj["/EF"]["/F"].read_bytes())
-                        print("saved: ", trg_file_path)
-                except:
-                    print("error ", trg_file_path)
+                        print(f"Attachment {trg_file_path} saved")
+                except Exception as e:
+                    print(f"Error while writing attachment {trg_file_path}: {e}")
                     continue
             else:
-                print("skipped: ", trg_filename)
+                print(f"Attachment {trg_filename} skipped, because it is not a PDF file")
 
 src_file_path = os.environ.get('DOCUMENT_WORKING_PATH')
 pass_file_path = "/usr/src/paperless/scripts/passwords.txt"
 consume_path = "/usr/src/paperless/consume/"
 
 if src_file_path is None:
-    print("no file path")
+    print("No file path available in environment variable 'DOCUMENT_WORKING_PATH'")
     exit(0)
 
 if not is_pdf(src_file_path):
-    print("not pdf")
+    print(f"File {src_file_path} not a PDF file")
     exit(0)
 
 if is_pdf_encrypted(src_file_path):
-    print("decrypting pdf")
+    print(f"Document {src_file_path} is encrypted. Proceeding with decryption")
     unlock_pdf(src_file_path)
 else:
-    print("not encrypted")
+    print(f"Document {src_file_path} is not encrypted. Proceeding without decryption")
 
 if pdf_has_attachments(src_file_path):
-    print("getting attachments")
+    print(f"Document {src_file_path} contains attachments. Proceeding with extracting the attachments")
     extract_pdf_attachments(src_file_path)
 else:
-    print("no attachments")
-
-
+    print(f"Document {src_file_path} has no attachments. Proceeding without decryption")


### PR DESCRIPTION
Most of the log lines in Paperless start with an uppercase letter and contain a bit of detail information (at least the filename).

This Pull Request follows this pattern. It changes the log output to something that
* contains detail information about what, where and why it is going wrong
* is more in line with the standard log messages of paperless